### PR TITLE
ci: add new workflow for issue comment triage

### DIFF
--- a/.github/workflows/issue-comment-triage
+++ b/.github/workflows/issue-comment-triage
@@ -14,7 +14,7 @@ jobs:
     name: "On author comment"
     runs-on: ubuntu-latest
     if: |
-      !github.event.issue.pull_request
+      github.event.issue.pull_request
       && ( contains(github.event.issue.labels.*.name, format('status{0} waiting response', ':')) 
         || contains(github.event.issue.labels.*.name, format('status{0} needs more info', ':')) 
       ) && github.event.author == github.event.issue.author

--- a/.github/workflows/issue-comment-triage
+++ b/.github/workflows/issue-comment-triage
@@ -1,0 +1,25 @@
+name: "Issue / Comment triage"
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: 'triage'
+
+jobs:
+  triage-commented-issue:
+    name: "On author comment"
+    runs-on: ubuntu-latest
+    if: |
+      !github.event.issue.pull_request
+      && ( contains(github.event.issue.labels.*.name, format('status{0} waiting response', ':')) 
+        || contains(github.event.issue.labels.*.name, format('status{0} needs more info', ':')) 
+      ) && github.event.author == github.event.issue.author
+    steps:
+      - name: Log github event
+        env:
+          $GITHUB_CONTEXT_LABELS: ${{ toJson(github.event.label) }}
+        run: echo "$GITHUB_CONTEXT_LABELS"

--- a/.github/workflows/issue-comment-triage.yml
+++ b/.github/workflows/issue-comment-triage.yml
@@ -11,31 +11,145 @@ permissions:
 concurrency:
   group: 'triage'
 
+env:
+  label_needs_more_info: ${{ format('status{0} needs more info', ':')}}
+  label_waiting_response: ${{ format('status{0} waiting response', ':')}}
+  label_pending: ${{ format('status{0} pending', ':')}}
+
 jobs:
+  check-conditions:
+    name: "Check conditions"
+    runs-on: ubuntu-latest
+    # Expose step outputs as job outputs
+    outputs:
+      has_need_response_labels: ${{ steps.check_labels.outputs.has_need_response_labels }}
+      has_pending_labels: ${{ steps.check_labels.outputs.has_pending_labels }}
+      owner_or_collaborator: ${{ steps.check_author.outputs.owner_or_collaborator }}
+      same_author: ${{ steps.check_author.outputs.same_author }}
+    steps:
+      - id: check_labels
+        name: 'labels'
+        env:
+          has_need_response_labels: ${{ contains(github.event.issue.labels.*.name, env.label_waiting_response) || contains(github.event.issue.labels.*.name, env.label_needs_more_info) }}
+          has_pending_labels: ${{ contains(github.event.issue.labels.*.name, env.label_pending) }}
+        shell: python
+        run: |
+          import os
+
+          def set_output(name, value):
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              print(f'{name}={value}', file=fh)
+
+          set_output('has_need_response_labels',os.getenv('has_need_response_labels'))
+          set_output('has_pending_labels',os.getenv('has_pending_labels'))
+      - id: check_author
+        name: 'author'
+        env:
+          owner_or_collaborator: ${{ github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' }}
+          same_author: ${{ github.event.comment.author == github.event.issue.author }}
+        shell: python
+        run: |
+          import os
+
+          def set_output(name, value):
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              print(f'{name}={value}', file=fh)     
+          
+          set_output('owner_or_collaborator',os.getenv('owner_or_collaborator'))
+          set_output('same_author',os.getenv('same_author'))
+
   triage-issue-commented-by-author:
     name: "On author comment"
     runs-on: ubuntu-latest
+    needs: 'check-conditions'
     if: |
-      github.event.issue.pull_request && ( 
-        contains(github.event.issue.labels.*.name, format('status{0} waiting response', ':')) || 
-        contains(github.event.issue.labels.*.name, format('status{0} needs more info', ':'))
-      ) && github.event.author == github.event.issue.author
+      !github.event.issue.pull_request && 
+      needs.check-conditions.outputs.has_need_response_labels == 'true' && 
+      needs.check-conditions.outputs.same_author == 'true'
     steps:
-      - name: Log github event
-        env:
-          $GITHUB_CONTEXT_LABELS: ${{ toJson(github.event.label) }}
-        run: echo "$GITHUB_CONTEXT_LABELS"
+      - name: "Generate token"
+        uses: tibdex/github-app-token@v2.1.0
+        id: generate_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: "Remove labels"
+        uses: actions/github-script@v7.0.1
+        continue-on-error: true
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          script: |
+            for (const label of [process.env.label_needs_more_info, process.env.label_waiting_response]) {
+              github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: [label]
+              });
+            }
+      - name: "Add labels"
+        uses: actions/github-script@v7.0.1
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: [process.env.label_pending]
+            });
+      - name: "Add comment"
+        uses: actions/github-script@v7.0.1
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          script: |
+            const commentText = `**Thank you for your answer.**
+            Your message will be reviewed shortly by the Print Maker Lab team.
+
+            _Please make sure, that you described everything in details so we can help you as soon as possible._`
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: commentText
+            });
+
   triage-issue-commented-by-owner:
     name: "On owner or collaborator comment"
     runs-on: ubuntu-latest
+    needs: 'check-conditions'
     if: |
-      github.event.issue.pull_request && 
-      contains(github.event.issue.labels.*.name, format('status{0} pending', ':')) && (
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'COLLABORATOR'
-      )
+      !github.event.issue.pull_request && 
+      needs.check-conditions.outputs.has_pending_labels == 'true' && 
+      needs.check-conditions.outputs.owner_or_collaborator == 'true'
     steps:
-      - name: Log github event
-        env:
-          $GITHUB_CONTEXT_LABELS: ${{ toJson(github.event.label) }}
-        run: echo "$GITHUB_CONTEXT_LABELS"
+      - name: "Generate token"
+        uses: tibdex/github-app-token@v2.1.0
+        id: generate_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: "Remove labels"
+        uses: actions/github-script@v7.0.1
+        continue-on-error: true
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          script: |
+            github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: [process.env.label_pending]
+            });
+      - name: "Add labels"
+        uses: actions/github-script@v7.0.1
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: [process.env.label_needs_more_info, process.env.label_waiting_response]
+            });

--- a/.github/workflows/issue-comment-triage.yml
+++ b/.github/workflows/issue-comment-triage.yml
@@ -14,9 +14,9 @@ jobs:
     name: "On author comment"
     runs-on: ubuntu-latest
     if: |
-      github.event.issue.pull_request
-      && ( contains(github.event.issue.labels.*.name, format('status{0} waiting response', ':')) 
-        || contains(github.event.issue.labels.*.name, format('status{0} needs more info', ':')) 
+      github.event.issue.pull_request && ( 
+        contains(github.event.issue.labels.*.name, format('status{0} waiting response', ':')) || 
+        contains(github.event.issue.labels.*.name, format('status{0} needs more info', ':'))
       ) && github.event.author == github.event.issue.author
     steps:
       - name: Log github event

--- a/.github/workflows/issue-comment-triage.yml
+++ b/.github/workflows/issue-comment-triage.yml
@@ -1,7 +1,9 @@
 name: "Issue / Comment triage"
+
 on:
   issue_comment:
-    types: [created]
+    types:
+      - created
 
 permissions:
   issues: write

--- a/.github/workflows/issue-comment-triage.yml
+++ b/.github/workflows/issue-comment-triage.yml
@@ -10,7 +10,7 @@ concurrency:
   group: 'triage'
 
 jobs:
-  triage-commented-issue:
+  triage-issue-commented-by-author:
     name: "On author comment"
     runs-on: ubuntu-latest
     if: |
@@ -18,6 +18,20 @@ jobs:
         contains(github.event.issue.labels.*.name, format('status{0} waiting response', ':')) || 
         contains(github.event.issue.labels.*.name, format('status{0} needs more info', ':'))
       ) && github.event.author == github.event.issue.author
+    steps:
+      - name: Log github event
+        env:
+          $GITHUB_CONTEXT_LABELS: ${{ toJson(github.event.label) }}
+        run: echo "$GITHUB_CONTEXT_LABELS"
+  triage-issue-commented-by-owner:
+    name: "On owner or collaborator comment"
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request && 
+      contains(github.event.issue.labels.*.name, format('status{0} pending', ':')) && (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
     steps:
       - name: Log github event
         env:

--- a/.github/workflows/issue-comment-triage.yml
+++ b/.github/workflows/issue-comment-triage.yml
@@ -20,6 +20,9 @@ jobs:
   check-conditions:
     name: "Check conditions"
     runs-on: ubuntu-latest
+    if: |
+      !github.event.issue.pull_request && 
+      github.event.issue.state == 'open'
     # Expose step outputs as job outputs
     outputs:
       has_need_response_labels: ${{ steps.check_labels.outputs.has_need_response_labels }}
@@ -46,7 +49,7 @@ jobs:
         name: 'author'
         env:
           owner_or_collaborator: ${{ github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' }}
-          same_author: ${{ github.event.comment.author == github.event.issue.author }}
+          same_author: ${{ github.event.comment.user.id == github.event.issue.user.id }}
         shell: python
         run: |
           import os
@@ -63,9 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: 'check-conditions'
     if: |
-      !github.event.issue.pull_request && 
       needs.check-conditions.outputs.has_need_response_labels == 'true' && 
-      needs.check-conditions.outputs.same_author == 'true'
+      ( needs.check-conditions.outputs.same_author == 'true' || needs.check-conditions.outputs.owner_or_collaborator == 'false' )
     steps:
       - name: "Generate token"
         uses: tibdex/github-app-token@v2.1.0
@@ -120,7 +122,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: 'check-conditions'
     if: |
-      !github.event.issue.pull_request && 
       needs.check-conditions.outputs.has_pending_labels == 'true' && 
       needs.check-conditions.outputs.owner_or_collaborator == 'true'
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -450,7 +450,8 @@ pids
 
 
 # System Files
-.DS_Store/
+.DS_Store
+**/.DS_Store
 
  nyc test coverage
 .nyc_output


### PR DESCRIPTION
# Description

New workflow for triage 'issue comments' from author, when they are in a 'waiting for response' state

## Type of change
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Translations
- [ ] Documentation
- [ ] Other... Please describe:

# How has this been tested?

<!-- Please provide a clear description of how this change was tested and instructions so we can reproduce.
    For UI changes, include screenshots of the relevant page(s) before and after the change.
    For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
 -->

- [x] Can be tested inside private repo

![image](https://github.com/PrintMakerLab/draft-repository/assets/9591166/1ab62684-e6a2-472d-b064-8744c3a86a41)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Does it closes one of the existing issues?

- [x] Yes
- [ ] No

<!-- If this PR closes an existing issue please add link to an open issue here: closes #XXXX (where XXXX - it's an issue number) -->

closes #27 


## Other information


# PR Checklist:
<!-- Please check if your PR fulfills the following requirements: -->
- [x] The pull request opens from the **issue/patch/feature/bugfix branch** (right side) and not main branch!
- [x] The pull request title, commit messages and code are follows our guidelines: [Contribution guide](https://github.com/PrintMakerLab/.github/blob/main/CONTRIBUTING.md) 
- [x] All commits are signed-off. See [How to sign-off commit](https://github.com/PrintMakerLab/.github/blob/main/how_to_sign-off_commits.md) 
- [x] The code changes are commented, particularly in hard-to-understand areas