### PR TITLE
fix: rework conditions for new issues triage workflow

### DIFF
--- a/.github/workflows/issue-new-issues-triage.yml
+++ b/.github/workflows/issue-new-issues-triage.yml
@@ -1,7 +1,7 @@
 name: "Issue / New issue triage"
 on:
   issues:
-    types: [labeled, opened]
+    types: [opened]
 
 permissions:
   issues: write

--- a/.github/workflows/issue-new-issues-triage.yml
+++ b/.github/workflows/issue-new-issues-triage.yml
@@ -10,15 +10,18 @@ jobs:
   add-comment-to-enhancement:
     name: "On enhancement"
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.label.name, format('issue{0} enhancement', ':')) && contains(github.event.label.name, format('status{0} pending', ':')) }}
+    if: ${{ contains(github.event.issue.labels.*.name, format('issue{0} enhancement', ':')) && contains(github.event.issue.labels.*.name, format('status{0} pending', ':')) }}
     steps:
-      - name: Log github event
-        env:
-          $GITHUB_CONTEXT_LABELS: ${{ toJson(github.event.label) }}
-        run: echo "$GITHUB_CONTEXT_LABELS"
+      - name: "Generate token"
+        uses: tibdex/github-app-token@v2.1.0
+        id: generate_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Add comment
         uses: actions/github-script@v7.0.1
         with:
+          github-token: ${{ steps.generate_token.outputs.token }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -29,15 +32,18 @@ jobs:
   add-comment-to-bug:
     name: "On bug report"
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.label.name, format('issue{0} bug', ':')) && contains(github.event.label.name, format('status{0} pending', ':')) }}
+    if: ${{ contains(github.event.issue.labels.*.name, format('issue{0} bug', ':')) && contains(github.event.issue.labels.*.name, format('status{0} pending', ':')) }}
     steps:
-      - name: Log github event
-        env:
-          $GITHUB_CONTEXT_LABELS: ${{ toJson(github.event.label) }}
-        run: echo "$GITHUB_CONTEXT_LABELS"
+      - name: "Generate token"
+        uses: tibdex/github-app-token@v2.1.0
+        id: generate_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Add comment
         uses: actions/github-script@v7.0.1
         with:
+          github-token: ${{ steps.generate_token.outputs.token }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -48,15 +54,18 @@ jobs:
   add-comment-to-question:
     name: "On question"
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.label.name, format('issue{0} question', ':')) && contains(github.event.label.name, format('status{0} pending', ':')) }}
+    if: ${{ contains(github.event.issue.labels.*.name, format('issue{0} question', ':')) && contains(github.event.issue.labels.*.name, format('status{0} pending', ':')) }}
     steps:
-      - name: Log github event
-        env:
-          $GITHUB_CONTEXT_LABELS: ${{ toJson(github.event.label) }}
-        run: echo "$GITHUB_CONTEXT_LABELS"
+      - name: "Generate token"
+        uses: tibdex/github-app-token@v2.1.0
+        id: generate_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Add comment
         uses: actions/github-script@v7.0.1
         with:
+          github-token: ${{ steps.generate_token.outputs.token }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/issue-new-issues-triage.yml
+++ b/.github/workflows/issue-new-issues-triage.yml
@@ -23,11 +23,16 @@ jobs:
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |
+            const comment = `**Thank you for submitting a feature request.**
+            Your proposal is open and will soon be reviewed by the Print Maker Lab team.
+            
+            _If your proposal is accepted and the Print Maker Lab team has bandwidth they will take on the issue, or else request you or other volunteers from the community to work on this issue._`
+            
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Thank you for submitting a feature request. Your proposal is open and will soon be reviewed by the Print Maker Lab team.<br><br>If your proposal is accepted and the Print Maker Lab team has bandwidth they will take on the issue, or else request you or other volunteers from the community to work on this issue.'
+              body: comment
             })
   add-comment-to-bug:
     name: "On bug report"
@@ -45,11 +50,16 @@ jobs:
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |
+            const comment = `**Thank you for submitting a bug report.**
+            Your message will be reviewed shortly by the Print Maker Lab team.
+            
+            _If your request is reproducible and the Print Maker Lab team has the bandwidth, they will look into it, or ask you or other community volunteers to work on it._`
+            
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Thank you for submitting a bug report. Your message will be reviewed shortly by the Print Maker Lab team.<br><br>If your request is reproducible and the Print Maker Lab team has the bandwidth, they will look into it, or ask you or other community volunteers to work on it.'
+              body: comment
             })
   add-comment-to-question:
     name: "On question"
@@ -67,9 +77,11 @@ jobs:
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |
+            const comment = `**Thank you for submitting your question.**
+            Your message will be reviewed shortly by the Print Maker Lab team.`
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Thank you for submitting your question. Your question will be reviewed shortly by the Print Maker Lab team.'
+              body: comment
             })


### PR DESCRIPTION
# Description

Changes:
* `github.event.label.name` was changed to `github.event.issue.labels.*.name`
* new `Generate token` step to fix the author of bot comments
* updated comment texts to be in the same style

## Type of change
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Translations
- [ ] Documentation
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Workflow is skipped, message can be only from default bot

## What is the new behavior(if this is a feature change)?
<!-- Please describe the behavior after changes -->

Workflow runs, and comment will be placed from organisation's bot

# How has this been tested?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Does it closes one of the existing issues?

- [x] Yes
- [ ] No

<!-- If this PR closes an existing issue please add link to an open issue here: closes #XXXX (where XXXX - it's an issue number) -->

closes #35 


## Other information


# PR Checklist:
<!-- Please check if your PR fulfills the following requirements: -->
- [x] The pull request opens from the **issue/patch/feature/bugfix branch** (right side) and not main branch!
- [x] The pull request title, commit messages and code are follows our guidelines: [Contribution guide](https://github.com/PrintMakerLab/.github/blob/main/CONTRIBUTING.md) 
- [x] All commits are signed-off. See [How to sign-off commit](https://github.com/PrintMakerLab/.github/blob/main/how_to_sign-off_commits.md) 
- [x] The code changes are commented, particularly in hard-to-understand areas